### PR TITLE
updating EBNF for AssignmentNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ This is the ENNF we defined so far.
 ```
 EBNF
     PROGRAM     ::= (ASSIGNMENT)* (LAYOUT)+
-    ASSIGNMENT  ::= VAR “=” VALUE
+    ASSIGNMENT  ::= VAR “=” (VALUE | CONSTRUCTOR)
     VAR         ::= CHAR(CHAR | NUMBER | ” _”)*
     STRING      ::= \” CHAR(CHAR)* \”
     CHAR        ::= “a”-”z” | “A”-”Z”
-    VALUE       ::= STRING | NUMBER | CONSTRUCTOR | VAR
+    VALUE       ::= STRING | NUMBER | VAR
     CONSTRUCTOR ::= FUNCNAME | FUNCNAME “(” ASSIGNMENT (, ASSIGNMENT)*  “)”
     FUNCNAME    ::= “Nav” | “Header” | “Content” | “Link” | “Image” | “Video” | “Footer” | “Button”
-    LAYOUT ::= (VAR | “Page”) “{“ ROW(ROW)* “}”
-    ROW ::= "[" (VAR | CONSTRUCTOR) (“\s” (VAR | CONSTRUCTOR))* "]"
+    LAYOUT      ::= (VAR | “Page”) “{“ ROW(ROW)* “}”
+    ROW         ::= "[" (VAR | CONSTRUCTOR) (“\s” (VAR | CONSTRUCTOR))* "]"
 ```

--- a/dsl/parser/ASTNode.py
+++ b/dsl/parser/ASTNode.py
@@ -2,15 +2,15 @@ from ..tokenizer.Token import *
 """
 EBNF
     PROGRAM     ::= (ASSIGNMENT)* (LAYOUT)+
-    ASSIGNMENT  ::= VAR “=” VALUE
+    ASSIGNMENT  ::= VAR “=” (VALUE | CONSTRUCTOR)
     VAR         ::= CHAR(CHAR | NUMBER | ” _”)*
     STRING      ::= \” CHAR(CHAR)* \”
     CHAR        ::= “a”-”z” | “A”-”Z”
-    VALUE       ::= STRING | NUMBER | CONSTRUCTOR | VAR
+    VALUE       ::= STRING | NUMBER | VAR
     CONSTRUCTOR ::= FUNCNAME | FUNCNAME “(” ASSIGNMENT (, ASSIGNMENT)*  “)”
     FUNCNAME    ::= “Nav” | “Header” | “Content” | “Link” | “Image” | “Video” | “Footer” | “Button”
-    LAYOUT ::= (VAR | “Page”) “{“ ROW(ROW)* “}”
-    ROW ::= "[" (VAR | CONSTRUCTOR) (“\s” (VAR | CONSTRUCTOR))* "]"
+    LAYOUT      ::= (VAR | “Page”) “{“ ROW(ROW)* “}”
+    ROW         ::= "[" (VAR | CONSTRUCTOR) (“\s” (VAR | CONSTRUCTOR))* "]"
 """
 
 
@@ -19,7 +19,7 @@ class ASTNode:
         Base class of ASTNode
     """
 
-    def __init__(self, list_of_tokens): 
+    def __init__(self, list_of_tokens):
         self.tokens = list_of_tokens
 
     def parse(self): pass
@@ -34,14 +34,13 @@ class ASTNode:
         return self.tokens[0]
 
 
-
 class ProgramNode(ASTNode):
 
     def __init__(self, list_of_tokens):
         super().__init__(list_of_tokens)
         self.assignments = []
         self.layouts = []
-    
+
     def parse(self):
         while self.has_next():
             tk = self.peek()
@@ -55,25 +54,28 @@ class ProgramNode(ASTNode):
                     new_layout_node = LayoutNode(self.tokens)
                     self.layouts.append(new_layout_node)
                     new_layout_node.parse()
-                else: 
-                    raise ParseError(f"unexpected Token {repr(tk)}: expected a '=' to build an assignment or a '{{' to build a layout statement")
+                else:
+                    raise ParseError(
+                        f"unexpected Token {repr(tk)}: expected a '=' to build an assignment or a '{{' to build a layout statement")
             else:
-                raise ParseError(f"unexpected Token {repr(tk)}: expected a variable or function keyword")
+                raise ParseError(
+                    f"unexpected Token {repr(tk)}: expected a variable or function keyword")
+
 
 class AssignmentNode(ASTNode):
 
     STRING = "STRING"
     FUNC = "FUNC"
     NUM = "NUM"
-    VAR = "VAR" # we allow a1 = a2; a2 = a3 ... this brings challenges to determine referencing loop loool, e.g. a1 = a2; a2 = a1 
-                # (well not really hard, this is actually a graph loop detection from a fixed starting point, leetcode easy)
+    VAR = "VAR"  # we allow a1 = a2; a2 = a3 ... this brings challenges to determine referencing loop loool, e.g. a1 = a2; a2 = a1
+    # (well not really hard, this is actually a graph loop detection from a fixed starting point, leetcode easy)
 
     TYPE_CONVERT_MAP = {
         Type.STRING: STRING,
         Type.NUMBER: NUM,
         Type.VARIABLE: VAR
     }
-                
+
     def __init__(self, list_of_tokens):
         super().__init__(list_of_tokens)
         self.var_name = None
@@ -83,7 +85,7 @@ class AssignmentNode(ASTNode):
     def parse(self):
         self.var_name = self.next().value
         self.next()  # get rid of the '=' sign
-        
+
         if not self.has_next():
             raise ParseError("reach the end of input unexpectedly")
 
@@ -91,28 +93,27 @@ class AssignmentNode(ASTNode):
         if tk.is_a(Type.RESERVED):
             self.assignment_type = self.FUNC
             self.assigned = ConstructorNode(self.tokens)
-        elif tk.is_a(Type.STRING) or  tk.is_a(Type.NUMBER) or tk.is_a(Type.VARIABLE):
+        elif tk.is_a(Type.STRING) or tk.is_a(Type.NUMBER) or tk.is_a(Type.VARIABLE):
             self.assignment_type = self.TYPE_CONVERT_MAP[tk.type]
             self.assigned = tk.value
             self.next()
         else:
-            raise ParseError(f"unexpected Token {repr(tk)}: expected a string, number or constructor as an assigned value")
-            
-        
+            raise ParseError(
+                f"unexpected Token {repr(tk)}: expected a string, number or constructor as an assigned value")
+
+
 class ConstructorNode(ASTNode):
 
     def parse(self):
-        return super().parse() #TODO
+        return super().parse()  # TODO
 
-    
+
 class LayoutNode(ASTNode):
 
     def parse(self):
-        return super().parse() #TODO
-                
+        return super().parse()  # TODO
+
 
 class ParseError(Exception):
     def __init__(self, message):
         self.message = message
-
-        

--- a/dsl/parser/test/ASTNodeSpec.py
+++ b/dsl/parser/test/ASTNodeSpec.py
@@ -2,6 +2,7 @@ import unittest
 from ..ASTNode import *
 from ...tokenizer.Token import *
 from ...tokenizer.Tokenizer import Tokenizer
+from .TestUtil import *
 
 class ASTNodeSpec(unittest.TestCase):
 

--- a/dsl/parser/test/ConstructorNodeSpec.py
+++ b/dsl/parser/test/ConstructorNodeSpec.py
@@ -1,0 +1,41 @@
+import unittest
+from .TestUtil import *
+
+
+class ConstructorNodeSpec(TestUtil):
+    def test_assignment_node_complex(self):
+        program = """
+                some_num = 1
+                some_str = "2"
+
+
+                some_var = var1
+
+                """
+        self.expectPass(program, {
+            'type': 'ProgramNode',
+            'assignments': [
+                {
+                    'type': 'AssignmentNode',
+                    'var_name': 'some_num',
+                    'assigned': 1
+                }, {
+                    'type': 'AssignmentNode',
+                    'var_name': 'some_str',
+                    'assigned': "2"
+                }, {
+                    'type': 'AssignmentNode',
+                    'var_name': 'some_var',
+                    'assigned': "var1"
+                },
+            ],
+            'layouts': []
+        })
+
+    def test_assignment_node_invalid(self):
+        program = "a = \n"
+        self.expectFail(program)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test.sh
+++ b/test.sh
@@ -8,4 +8,5 @@ python3 -m dsl.tokenizer.test.TokenizerSpec
 echo ""
 echo "-------- Parser Tests --------"
 python3 -m dsl.parser.test.ASTNodeSpec
+python3 -m dsl.parser.test.ConstructorNodeSpec
 


### PR DESCRIPTION
Otherwise, we are allowing recursive constructor definitions.

Other whitespace changes are python linter changes.